### PR TITLE
do not strip www

### DIFF
--- a/routes/css.js
+++ b/routes/css.js
@@ -14,7 +14,7 @@ router.get('/', function (req, res, next) {
   var errors = validateQueryParams(req.query)
 
   if (isBlank(errors)) {
-    var url = normalizeUrl(req.query.url)
+    var url = normalizeUrl(req.query.url, { stripWWW: false })
     getCss(url)
       .then(function (css) {
         res.json({ css: css })

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -15,7 +15,7 @@ router.get('/', function (req, res, next) {
   var errors = validateQueryParams(req.query)
 
   if (isBlank(errors)) {
-    var url = normalizeUrl(req.query.url)
+    var url = normalizeUrl(req.query.url, { stripWWW: false })
     getCss(url)
       .then(function (css) {
         res.json({
@@ -44,7 +44,7 @@ router.get('/summary', function (req, res, next) {
   var errors = validateQueryParams(req.query)
 
   if (isBlank(errors)) {
-    var url = normalizeUrl(req.query.url)
+    var url = normalizeUrl(req.query.url, { stripWWW: false })
     getCss(url)
       .then(function (css) {
         var stats = cssStats(css.css, { importantDeclarations: true })


### PR DESCRIPTION
Hi,

Thanks for creating this api...

The change is to support in /stats and /css urls like: http://www.sub.domain.com 

(Currently 'www' is removed resulting in: sub.domain.com.)

(NOTE: getcss also does not strip www, bringing cssstats-api in line with get-css: https://github.com/cssstats/get-css/blob/1.2.1/index.js#L29)

Thank you!
